### PR TITLE
Allow custom claims

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,7 +2,7 @@ import extend = require("extend");
 import {IncomingMessage, ServerResponse} from "http";
 import * as jwt from "jsonwebtoken";
 
-import Authenticator, {TokenWithExpire} from "./authenticator";
+import Authenticator, {TokenWithExpiry} from "./authenticator";
 import BaseClient from "./base_client";
 import {AuthenticateOptions, RequestOptions} from "./common";
 
@@ -60,7 +60,7 @@ export default class App {
     this.authenticator.authenticate(request, response, options);
   }
 
-  generateAccessToken(options: AuthenticateOptions): TokenWithExpire {
+  generateAccessToken(options: AuthenticateOptions): TokenWithExpiry {
     return this.authenticator.generateAccessToken(options);
   }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,7 +2,7 @@ import extend = require("extend");
 import {IncomingMessage, ServerResponse} from "http";
 import * as jwt from "jsonwebtoken";
 
-import Authenticator from "./authenticator";
+import Authenticator, {TokenWithExpire} from "./authenticator";
 import BaseClient from "./base_client";
 import {AuthenticateOptions, RequestOptions} from "./common";
 
@@ -58,6 +58,10 @@ export default class App {
 
   authenticate(request: IncomingMessage, response: ServerResponse, options: AuthenticateOptions) {
     this.authenticator.authenticate(request, response, options);
+  }
+
+  generateAccessToken(options: AuthenticateOptions): TokenWithExpire {
+    return this.authenticator.generateAccessToken(options);
   }
 
   private scopeRequestOptions(prefix: string, options: RequestOptions): RequestOptions {

--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -11,6 +11,10 @@ export interface TokenWithExpire {
   expire: number;
 }
 
+export interface RefreshToken {
+  value: string;
+}
+
 export default class Authenticator {
   constructor(
       private appId: string,
@@ -43,7 +47,7 @@ export default class Authenticator {
       access_token: token,
       token_type: "bearer",
       expires_in: TOKEN_EXPIRY,
-      refresh_token: refreshToken,
+      refresh_token: refreshToken.value,
     });
   }
 
@@ -94,7 +98,7 @@ export default class Authenticator {
       access_token: newAccessToken,
       token_type: "bearer",
       expires_in: TOKEN_EXPIRY,
-      refresh_token: newRefreshToken,
+      refresh_token: newRefreshToken.value,
     });
   }
 
@@ -117,7 +121,7 @@ export default class Authenticator {
     };
   }
 
-  private generateRefreshToken(options: AuthenticateOptions): string {
+  private generateRefreshToken(options: AuthenticateOptions): RefreshToken {
     let now = Math.floor(Date.now() / 1000);
 
     let claims = {
@@ -128,7 +132,9 @@ export default class Authenticator {
       sub: options.userId,
     };
 
-    return jwt.sign(claims, this.appKeySecret);
+    return {
+      value: jwt.sign(claims, this.appKeySecret),
+    };
   }
 }
 

--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -102,6 +102,7 @@ export default class Authenticator {
       iat: now - TOKEN_LEEWAY,
       exp: now + TOKEN_EXPIRY - TOKEN_LEEWAY,
       sub: options.userId,
+      ...options.serviceClaims,
     };
 
     return jwt.sign(claims, this.appKeySecret);

--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -6,13 +6,13 @@ import {AuthenticateOptions} from "./common";
 const TOKEN_LEEWAY = 30;
 const TOKEN_EXPIRY = 24*60*60;
 
-export interface TokenWithExpire {
+export interface TokenWithExpiry {
   token: string;
-  expire: number;
+  expires_in: number;
 }
 
 export interface RefreshToken {
-  value: string;
+  token: string;
 }
 
 export default class Authenticator {
@@ -47,7 +47,7 @@ export default class Authenticator {
       access_token: token,
       token_type: "bearer",
       expires_in: TOKEN_EXPIRY,
-      refresh_token: refreshToken.value,
+      refresh_token: refreshToken.token,
     });
   }
 
@@ -98,26 +98,25 @@ export default class Authenticator {
       access_token: newAccessToken,
       token_type: "bearer",
       expires_in: TOKEN_EXPIRY,
-      refresh_token: newRefreshToken.value,
+      refresh_token: newRefreshToken.token,
     });
   }
 
-  generateAccessToken(options: AuthenticateOptions): TokenWithExpire {
+  generateAccessToken(options: AuthenticateOptions): TokenWithExpiry {
     let now = Math.floor(Date.now() / 1000);
-    let expire = now + TOKEN_EXPIRY - TOKEN_LEEWAY;
 
     let claims = {
       app: this.appId,
       iss: this.appKeyId,
       iat: now - TOKEN_LEEWAY,
-      exp: expire,
+      exp: now + TOKEN_EXPIRY - TOKEN_LEEWAY,
       sub: options.userId,
       ...options.serviceClaims,
     };
 
     return {
       token: jwt.sign(claims, this.appKeySecret),
-      expire: expire,
+      expires_in: TOKEN_EXPIRY,
     };
   }
 
@@ -133,7 +132,7 @@ export default class Authenticator {
     };
 
     return {
-      value: jwt.sign(claims, this.appKeySecret),
+      token: jwt.sign(claims, this.appKeySecret),
     };
   }
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -23,4 +23,5 @@ export interface RequestOptions {
 
 export interface AuthenticateOptions {
   userId: string;
+  serviceClaims: any;
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,7 +1,7 @@
 import {Readable} from "stream";
 
 export type Headers = {
-  [key: string]: string;
+  [key: string]: string | string[];
 };
 
 export class ErrorResponse {


### PR DESCRIPTION
### What?
* Allow custom `serviceClaims` to be added to token claims.
* Make generateAccessToken public

#### Why?
* Feeds needs to set permissions in the token.
* Feeds needs to be able to generate its own tokens to use when publishing to Feeds.

----

CC @pusher/sigsdk