### PR TITLE
Authenticate synchronously instead of writing to http.response

### DIFF
--- a/examples/auth.js
+++ b/examples/auth.js
@@ -10,7 +10,12 @@ var pusher = new PusherApp({
 var app = express();
 
 app.post('/', bodyParser.urlencoded(), function (req, res) {
-  pusher.authenticate(req, res, {});
+  try {
+    const data = pusher.authenticate(req, {})
+    res.send(data);
+  } catch (err) {
+    res.send('AuthError: ' + err.message);
+  }
 });
 
 app.listen(3000, function () {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,8 +1,9 @@
 import extend = require("extend");
-import {IncomingMessage, ServerResponse} from "http";
+import {IncomingMessage} from "http";
+import {IncomingMessageWithBody} from "./common";
 import * as jwt from "jsonwebtoken";
 
-import Authenticator, {TokenWithExpiry} from "./authenticator";
+import Authenticator, { TokenWithExpiry, AuthenticationResponse } from "./authenticator";
 import BaseClient from "./base_client";
 import {AuthenticateOptions, RequestOptions} from "./common";
 
@@ -56,8 +57,8 @@ export default class App {
     return this.client.request(options);
   }
 
-  authenticate(request: IncomingMessage, response: ServerResponse, options: AuthenticateOptions) {
-    this.authenticator.authenticate(request, response, options);
+  authenticate(request: IncomingMessageWithBody, options: AuthenticateOptions): AuthenticationResponse {
+    return this.authenticator.authenticate(request, options);
   }
 
   generateAccessToken(options: AuthenticateOptions): TokenWithExpiry {

--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -1,18 +1,29 @@
-import {IncomingMessage, ServerResponse} from "http";
+import {IncomingMessage} from "http";
 import * as jwt from "jsonwebtoken";
 
-import {AuthenticateOptions} from "./common";
+import {AuthenticateOptions, IncomingMessageWithBody} from "./common";
+import {UnsupportedGrantTypeError, InvalidGrantTypeError} from "./errors";
 
 const TOKEN_LEEWAY = 30;
 const TOKEN_EXPIRY = 24*60*60;
+const CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
+const REFRESH_TOKEN_GRANT_TYPE = "refresh_token";
 
 export interface TokenWithExpiry {
+
   token: string;
   expires_in: number;
 }
 
 export interface RefreshToken {
   token: string;
+}
+
+export interface AuthenticationResponse {
+  access_token: string | TokenWithExpiry;
+  token_type: string;
+  expires_in: number;
+  refresh_token: string;
 }
 
 export default class Authenticator {
@@ -23,83 +34,63 @@ export default class Authenticator {
 
   }
 
-  authenticate(request: IncomingMessage, response: ServerResponse, options: AuthenticateOptions) {
-    let body = (<any>request).body; // FIXME
+  authenticate(request: IncomingMessageWithBody, options: AuthenticateOptions): AuthenticationResponse {
+    let body = request.body; // FIXME - we should figure out better way then just rely on express.js body parser.
     let grantType = body["grant_type"];
 
-    if (grantType === "client_credentials") {
-      this.authenticateWithClientCredentials(response, options);
-    } else if (grantType === "refresh_token") {
-      let oldRefreshToken = body["refresh_token"];
-      this.authenticateWithRefreshToken(oldRefreshToken, response, options);
-    } else {
-      writeResponse(response, 401, {
-        error: "unsupported_grant_type",
-        // TODO error_uri
-      });
+    switch (grantType) {
+      case CLIENT_CREDENTIALS_GRANT_TYPE:
+        return this.authenticateWithClientCredentials(options);
+      case REFRESH_TOKEN_GRANT_TYPE:
+        let oldRefreshToken = body[REFRESH_TOKEN_GRANT_TYPE];
+        return this.authenticateWithRefreshToken(oldRefreshToken, options);
+      default:
+        throw new UnsupportedGrantTypeError(`Requested type: "${grantType}" is not supported`);
     }
   }
 
-  private authenticateWithClientCredentials(response: ServerResponse, options: AuthenticateOptions) {
+  private authenticateWithClientCredentials(options: AuthenticateOptions): AuthenticationResponse { 
     let {token} = this.generateAccessToken(options);
     let refreshToken = this.generateRefreshToken(options);
-    writeResponse(response, 200, {
+    
+    return {
       access_token: token,
       token_type: "bearer",
       expires_in: TOKEN_EXPIRY,
       refresh_token: refreshToken.token,
-    });
+    };
   }
 
-  private authenticateWithRefreshToken(oldRefreshToken: string, response: ServerResponse, options: AuthenticateOptions) {
-    let decoded: any;
+  private authenticateWithRefreshToken(oldRefreshToken: string, options: AuthenticateOptions): AuthenticationResponse {
+      let decoded: any;
 
-    try {
-      decoded = jwt.verify(oldRefreshToken, this.appKeySecret, {
-        issuer: `api_keys/${this.appKeyId}`,
-        clockTolerance: TOKEN_LEEWAY,
-      });
-    } catch (e) {
-      let description: string;
-      if (e instanceof jwt.TokenExpiredError) {
-        description = "refresh token has expired";
-      } else {
-        description = "refresh token is invalid";
+      try {
+        decoded = jwt.verify(oldRefreshToken, this.appKeySecret, {
+          issuer: `keys/${this.appKeyId}`,
+          clockTolerance: TOKEN_LEEWAY,
+        });
+      } catch (e) {
+        let description: string = (e instanceof jwt.TokenExpiredError) ? "refresh token has expired" : "refresh token is invalid";
+        throw new InvalidGrantTypeError(description);
       }
-      writeResponse(response, 401, {
-        error: "invalid_grant",
-        error_description: description,
-        // TODO error_uri
-      });
-      return;
-    }
 
-    if (decoded.refresh !== true) {
-      writeResponse(response, 401, {
-        error: "invalid_grant",
-        error_description: "refresh token does not have a refresh claim",
-        // TODO error_uri
-      });
-      return;
-    }
+      if (decoded.refresh !== true) {
+        throw new InvalidGrantTypeError("refresh token does not have a refresh claim");
+      }
 
-    if (options.userId !== decoded.sub) {
-      writeResponse(response, 401, {
-        error: "invalid_grant",
-        error_description: "refresh token has an invalid user id",
-        // TODO error_uri
-      });
-      return;
-    }
+      if (options.userId !== decoded.sub) {
+        throw new InvalidGrantTypeError("refresh token has an invalid user id");
+      }
 
-    let newAccessToken = this.generateAccessToken(options);
-    let newRefreshToken = this.generateRefreshToken(options);
-    writeResponse(response, 200, {
-      access_token: newAccessToken,
-      token_type: "bearer",
-      expires_in: TOKEN_EXPIRY,
-      refresh_token: newRefreshToken.token,
-    });
+      let newAccessToken = this.generateAccessToken(options);
+      let newRefreshToken = this.generateRefreshToken(options);
+
+      return {
+        access_token: newAccessToken,
+        token_type: "bearer",
+        expires_in: TOKEN_EXPIRY,
+        refresh_token: newRefreshToken.token,
+      };
   }
 
   generateAccessToken(options: AuthenticateOptions): TokenWithExpiry {
@@ -135,9 +126,4 @@ export default class Authenticator {
       token: jwt.sign(claims, this.appKeySecret),
     };
   }
-}
-
-function writeResponse(response: ServerResponse, statusCode: number, body: any) {
-  response.writeHead(statusCode, { "Content-Type": "application/json" });
-  response.end(JSON.stringify(body));
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,4 +1,5 @@
 import {Readable} from "stream";
+import {IncomingMessage} from "http";
 
 export type Headers = {
   [key: string]: string | string[];
@@ -11,6 +12,10 @@ export class ErrorResponse {
     public readonly description: any) {
 
   }
+}
+
+export interface IncomingMessageWithBody extends IncomingMessage {
+  body: any;
 }
 
 export interface RequestOptions {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,15 @@
+export class UnsupportedGrantTypeError extends Error {
+  constructor(
+    public readonly message: string) {
+    super(message);
+    this.name = "UnsupportedGrantTypeError";
+  }
+}
+
+export class InvalidGrantTypeError extends Error {
+  constructor(
+    public readonly message: string) {
+    super(message);
+    this.name = "InvalidGrantTypeError";
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export {Readable as Readable} from "stream";
 export {IncomingMessage as IncomingMessage} from "http";
 
 export {ErrorResponse} from "./common";
+export {UnsupportedGrantTypeError, InvalidGrantTypeError} from './errors';
 
 export {default as App} from "./app";
 


### PR DESCRIPTION
Fix types for requests

### What?

Like https://github.com/pusher/pusher-platform-nodejs/pull/14, but squashed, and rebased onto the current master.

#### Why?

...

#### How?

...

----

CC @pusher/sigsdk