### PR TITLE
Change artifact name to pusher-platform-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "pusher-platform",
-  "version": "0.2.0",
+  "name": "pusher-platform-node",
+  "version": "0.3.0",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {


### PR DESCRIPTION
#### Why?

Because consistency.

----

CC @pusher/sigsdk